### PR TITLE
feat: default credentials

### DIFF
--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -273,6 +273,26 @@ export class CredentialsHelper extends ICredentialsHelper {
 		);
 	}
 
+	async getCredentialsByType(type: string, userId: string): Promise<Credentials> {
+		try {
+			const credential = await this.sharedCredentialsRepository
+				.findOneOrFail({
+					relations: ['credentials'],
+					where: { credentials: { type }, userId },
+				})
+				.then((shared) => shared.credentials);
+
+			return new Credentials(
+				{ id: credential.id, name: credential.name },
+				credential.type,
+				credential.nodesAccess,
+				credential.data,
+			);
+		} catch (error) {
+			throw new CredentialNotFoundError('default', type);
+		}
+	}
+
 	/**
 	 * Returns all the properties of the credentials with the given name
 	 */

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -1956,9 +1956,31 @@ export async function getCredentials(
 		);
 	}
 
+	if (nodeType.description.defaultCredentials) {
+		const credentials = await additionalData.credentialsHelper.getCredentialsByType(
+			type,
+			additionalData.userId,
+		);
+
+		if (!credentials) {
+			throw new NodeOperationError(node, 'Credentials not found');
+		}
+
+		node.credentials = {
+			[type]: {
+				id: credentials.id!,
+				name: credentials.name,
+			},
+		};
+	}
+
 	// Hardcode for now for security reasons that only a single node can access
 	// all credentials
-	const fullAccess = [HTTP_REQUEST_NODE_TYPE].includes(node.type);
+	// HONEYBOOK: we check defaultCredentials here so later in this function we don't get blocked by
+	// the fact that nodeType.description.credentials is undefined
+	const fullAccess =
+		nodeType.description.defaultCredentials !== undefined ||
+		[HTTP_REQUEST_NODE_TYPE].includes(node.type);
 
 	let nodeCredentialDescription: INodeCredentialDescription | undefined;
 	if (!fullAccess) {

--- a/packages/n8n-nodes-honeybook/credentials/HoneyBookApi.credentials.ts
+++ b/packages/n8n-nodes-honeybook/credentials/HoneyBookApi.credentials.ts
@@ -12,12 +12,6 @@ export class HoneyBookApi implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
-			displayName: 'Context user',
-			name: 'ctxu',
-			type: 'string',
-			default: '',
-		},
-		{
 			displayName: 'Context company',
 			name: 'ctxc',
 			type: 'string',
@@ -29,7 +23,6 @@ export class HoneyBookApi implements ICredentialType {
 		type: 'generic',
 		properties: {
 			qs: {
-				ctxu: '={{$credentials.ctxu}}',
 				ctxc: '={{$credentials.ctxc}}',
 			},
 		},

--- a/packages/n8n-nodes-honeybook/nodes/HoneyBookAction/HoneyBookAction.node.ts
+++ b/packages/n8n-nodes-honeybook/nodes/HoneyBookAction/HoneyBookAction.node.ts
@@ -31,12 +31,7 @@ export class HoneyBookAction implements INodeType {
 		},
 		inputs: ['main'],
 		outputs: ['main'],
-		credentials: [
-			{
-				name: 'honeyBookApi',
-				required: true,
-			},
-		],
+		defaultCredentials: 'honeyBookApi',
 		properties: [
 			{
 				displayName: 'Action',

--- a/packages/n8n-nodes-honeybook/nodes/HoneyBookTrigger/HoneyBookTrigger.node.ts
+++ b/packages/n8n-nodes-honeybook/nodes/HoneyBookTrigger/HoneyBookTrigger.node.ts
@@ -25,12 +25,7 @@ export class HoneyBookTrigger implements INodeType {
 		},
 		inputs: [],
 		outputs: ['main'],
-		credentials: [
-			{
-				name: 'honeyBookApi',
-				required: true,
-			},
-		],
+		defaultCredentials: 'honeyBookApi',
 		webhooks: [
 			{
 				name: 'default',

--- a/packages/n8n-nodes-honeybook/nodes/HoneyBookTrigger/HoneyBookTrigger.node.ts
+++ b/packages/n8n-nodes-honeybook/nodes/HoneyBookTrigger/HoneyBookTrigger.node.ts
@@ -9,6 +9,8 @@ import type {
 	IDataObject,
 } from 'n8n-workflow';
 
+import { honeyBookApiRequest } from './honeyBookApi';
+
 export class HoneyBookTrigger implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Trigger',
@@ -27,6 +29,14 @@ export class HoneyBookTrigger implements INodeType {
 			{
 				name: 'honeyBookApi',
 				required: true,
+			},
+		],
+		webhooks: [
+			{
+				name: 'default',
+				httpMethod: 'POST',
+				responseMode: 'onReceived',
+				path: 'webhook',
 			},
 		],
 		properties: [
@@ -77,12 +87,40 @@ export class HoneyBookTrigger implements INodeType {
 	webhookMethods = {
 		default: {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
+				/**
+				 * n8n calls this before creating/updating the webhook,
+				 * I think it's redundant to make 2 calls to the API every time.
+				 * the create endpoint in our API will accept an optional existingSubscriptionId param and drop it if it exists.
+				 * this way we always end up with the most up-to-date webhook configuration.
+				 */
 				return false;
 			},
 			async create(this: IHookFunctions): Promise<boolean> {
+				const webhookUrl = this.getNodeWebhookUrl('default');
+				const webhookData = this.getWorkflowStaticData('node');
+				const trigger = this.getNodeParameter('trigger') as string;
+				const body: IDataObject = {
+					existing_subscription_id: webhookData.subscriptionId,
+					webhook_url: webhookUrl,
+					trigger,
+				};
+				const { _id } = await honeyBookApiRequest.call(
+					this,
+					'POST',
+					'/automations/subscriptions',
+					body,
+				);
+				webhookData.subscriptionId = _id;
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
+				const webhookData = this.getWorkflowStaticData('node');
+				await honeyBookApiRequest.call(
+					this,
+					'DELETE',
+					`/automations/subscriptions/${webhookData.subscriptionId}`,
+				);
+				delete webhookData.subscriptionId;
 				return true;
 			},
 		},

--- a/packages/n8n-nodes-honeybook/nodes/HoneyBookTrigger/honeyBookApi.ts
+++ b/packages/n8n-nodes-honeybook/nodes/HoneyBookTrigger/honeyBookApi.ts
@@ -6,7 +6,7 @@ export async function honeyBookApiRequest(
 	path: string,
 	body: any = {},
 ) {
-	const response = await this.helpers.httpRequest({
+	const response = await this.helpers.httpRequestWithAuthentication.call(this, 'honeyBookApi', {
 		baseURL: 'http://localhost:8000/api/v2',
 		url: path,
 		method,

--- a/packages/n8n-nodes-honeybook/nodes/HoneyBookTrigger/honeyBookApi.ts
+++ b/packages/n8n-nodes-honeybook/nodes/HoneyBookTrigger/honeyBookApi.ts
@@ -1,0 +1,17 @@
+import type { IHookFunctions, IHttpRequestMethods } from 'n8n-workflow';
+
+export async function honeyBookApiRequest(
+	this: IHookFunctions,
+	method: IHttpRequestMethods,
+	path: string,
+	body: any = {},
+) {
+	const response = await this.helpers.httpRequest({
+		baseURL: 'http://localhost:8000/api/v2',
+		url: path,
+		method,
+		body,
+	});
+
+	return response;
+}

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -211,6 +211,8 @@ export abstract class ICredentialsHelper {
 		type: string,
 	): Promise<ICredentials>;
 
+	abstract getCredentialsByType(type: string, userId: string): Promise<ICredentials>;
+
 	abstract getDecrypted(
 		additionalData: IWorkflowExecuteAdditionalData,
 		nodeCredentials: INodeCredentialsDetails,
@@ -1718,6 +1720,7 @@ export interface INodeTypeDescription extends INodeTypeBaseDescription {
 	outputNames?: string[];
 	properties: INodeProperties[];
 	credentials?: INodeCredentialDescription[];
+	defaultCredentials?: string;
 	maxNodes?: number; // How many nodes of that type can be created in a workflow
 	polling?: true | undefined;
 	supportsCORS?: true | undefined;


### PR DESCRIPTION
## Summary
https://honeybook.atlassian.net/browse/CORE-11432

For HB nodes we don't want users to choose credentials.
This means we cannot define `credentials` in node descriptions.
But if we don't define it - `getCredentials` will block us from using `httpRequestWithAuthentication`.

The solution is to extend `getCredentials` with a `defaultCredentials` logic:
If a node description has `defaultCredentials`, we will fetch credentials by type and set it on `node.credentials` (as if the user selected it). We also turn on `fullAccess` which prevents  `getCredentials` doing extra validation.

In the end we get to `credentialsHelper.getDecrypted` just like a normal case and get the actual value of the credentials.